### PR TITLE
Potential fix for code scanning alert no. 22: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -1100,15 +1100,23 @@ function showOrderConfirmationModal(orderData) {
     console.error("Modal elements not found");
     return;
   }  
+  const escapeHTML = (str) => str.replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  }[char]));
+  
   let summaryHTML = `
     <div class="order-summary-section">
       <h3>Order Summary</h3>
-      <p><strong>Name:</strong> ${orderData.customerName}</p>
-      <p><strong>Phone:</strong> ${orderData.phoneNumber}</p>
-      <p><strong>Order Type:</strong> ${orderData.orderType}</p>
+      <p><strong>Name:</strong> ${escapeHTML(orderData.customerName)}</p>
+      <p><strong>Phone:</strong> ${escapeHTML(orderData.phoneNumber)}</p>
+      <p><strong>Order Type:</strong> ${escapeHTML(orderData.orderType)}</p>
       ${orderData.orderType === 'Delivery' ? `
-        <p><strong>Delivery Distance:</strong> ${orderData.deliveryDistance ? orderData.deliveryDistance.toFixed(1)+'km' : 'Unknown'}</p>
-        ${orderData.deliveryAddress ? `<p><strong>Delivery Address:</strong> ${orderData.deliveryAddress}</p>` : ''}
+        <p><strong>Delivery Distance:</strong> ${orderData.deliveryDistance ? escapeHTML(orderData.deliveryDistance.toFixed(1)) + 'km' : 'Unknown'}</p>
+        ${orderData.deliveryAddress ? `<p><strong>Delivery Address:</strong> ${escapeHTML(orderData.deliveryAddress)}</p>` : ''}
       ` : ''}
     </div>
     


### PR DESCRIPTION
Potential fix for [https://github.com/tubai19/bgfoodorder/security/code-scanning/22](https://github.com/tubai19/bgfoodorder/security/code-scanning/22)

To fix the issue, all user-provided data embedded in the `summaryHTML` string must be sanitized or escaped to prevent it from being interpreted as HTML. The best approach is to use a library like `DOMPurify` to sanitize the HTML or to escape the data manually using a utility function that replaces special characters (`<`, `>`, `&`, etc.) with their HTML-escaped equivalents. This ensures that the data is treated as plain text rather than executable HTML/JavaScript.

The fix involves:
1. Escaping all user-provided data (`orderData.customerName`, `orderData.phoneNumber`, etc.) before embedding it in the `summaryHTML` string.
2. Replacing the direct assignment to `innerHTML` with sanitized or escaped content.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
